### PR TITLE
[Feat, Fix] 로그아웃 및 토큰 삭제 간소화, 응급 대처법 상세화면 즐겨찾기 오류 수정

### DIFF
--- a/app/src/main/java/com/example/resq/presentaion/resqbookmark/component/BookmarkOptions.kt
+++ b/app/src/main/java/com/example/resq/presentaion/resqbookmark/component/BookmarkOptions.kt
@@ -25,7 +25,7 @@ fun BookmarkOptions(onClick: (String) -> Unit) {
             )
     ) {
         Text(
-            text = stringResource(R.string.cancel),
+            text = delete,
             modifier = Modifier.padding(4.dp)
         )
     }

--- a/app/src/main/java/com/example/resq/presentaion/resqdetail/ResQDetailScreen.kt
+++ b/app/src/main/java/com/example/resq/presentaion/resqdetail/ResQDetailScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -23,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -53,12 +53,16 @@ fun ResQDetailScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val resQDetail by viewModel.resQDetail.collectAsState()
     var searchText by remember { mutableStateOf("") }
-    var isFavorite by remember { mutableStateOf(false) }
+    val isFavorite = remember { mutableStateMapOf<String, Boolean>() }
     val language = Locale.current.language
 
     LaunchedEffect(resQ) {
-        viewModel.getResQDetail(resQ, language)
-        isFavorite = FAVORITE_RESQ_LIST.any { it.resQSlug == resQ }
+        viewModel.getResQDetail(resQ, language) { resQDetail ->
+            resQDetail.forEach { resQInfo ->
+                isFavorite[resQInfo.slug] =
+                    FAVORITE_RESQ_LIST.any { it.resQSlug == resQInfo.slug }
+            }
+        }
     }
 
     Column(
@@ -95,17 +99,20 @@ fun ResQDetailScreen(
                                 fontSize = 30.sp,
                                 modifier = Modifier.weight(1f)
                             )
+                            val favoriteState = isFavorite.getOrDefault(resQ.slug, false)
                             IconButton(
                                 onClick = {
-                                    isFavorite = !isFavorite
+                                    isFavorite[resQ.slug] = !favoriteState
                                     resQ.resQIndex?.let {
-                                        if (isFavorite) viewModel.addToFavoriteResQList(it)
-                                        else viewModel.deleteToFavoriteResQList(it)
+                                        if (isFavorite[resQ.slug] == true) ResQDetailViewModel().addToFavoriteResQList(
+                                            it
+                                        )
+                                        else ResQDetailViewModel().deleteToFavoriteResQList(it)
                                     }
                                 }
                             ) {
                                 Icon(
-                                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                    imageVector = if (isFavorite[resQ.slug] == true) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
                                     contentDescription = "Favorite",
                                 )
                             }

--- a/app/src/main/java/com/example/resq/presentaion/resqdetail/ResQDetailViewModel.kt
+++ b/app/src/main/java/com/example/resq/presentaion/resqdetail/ResQDetailViewModel.kt
@@ -19,7 +19,11 @@ class ResQDetailViewModel : ViewModel() {
     private val _resQDetail = MutableStateFlow(emptyList<ResQDetailResponse>())
     val resQDetail: MutableStateFlow<List<ResQDetailResponse>> = _resQDetail
 
-    fun getResQDetail(resQ: String, language: String) {
+    fun getResQDetail(
+        resQ: String,
+        language: String,
+        onResQDetail: (List<ResQDetailResponse>) -> Unit
+    ) {
         viewModelScope.launch {
             _isLoading.value = true
             try {
@@ -35,6 +39,7 @@ class ResQDetailViewModel : ViewModel() {
             } catch (e: Exception) {
                 Log.d("getResQDetail", e.message.toString())
             }
+            onResQDetail(_resQDetail.value)
             _isLoading.value = false
         }
     }

--- a/app/src/main/java/com/example/resq/presentaion/resqdetail/model/ResQDetailResponse.kt
+++ b/app/src/main/java/com/example/resq/presentaion/resqdetail/model/ResQDetailResponse.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class ResQDetailResponse(
     @SerializedName("index") val resQIndex: Int?,
-    @SerializedName("slug") val slug: String?,
+    @SerializedName("slug") val slug: String,
     @SerializedName("emoji") val resQEmoji: String?,
     @SerializedName("emer_title") val resQTitle: ResQTitleLanguage?,
     @SerializedName("description") val description: ResQDescriptionDetail?,

--- a/app/src/main/java/com/example/resq/presentaion/sign/GoogleSignViewModel.kt
+++ b/app/src/main/java/com/example/resq/presentaion/sign/GoogleSignViewModel.kt
@@ -61,16 +61,10 @@ class GoogleSignViewModel : ViewModel() {
         editor.apply()
     }
 
-    fun removeUserToken(context: Context) {
-        val sharedPreferences: SharedPreferences =
-            context.getSharedPreferences("UserPrefs", Context.MODE_PRIVATE)
-        val editor = sharedPreferences.edit()
-        editor.remove("userToken")
-        editor.apply()
-    }
-
-    fun signOut(googleSignInClient: GoogleSignInClient) {
-        googleSignInClient.signOut()
+    fun signOut(context: Context, googleSignInClient: GoogleSignInClient) {
+        googleSignInClient.revokeAccess().addOnCompleteListener {
+            context.getSharedPreferences("UserPrefs", Context.MODE_PRIVATE).edit().clear().apply()
+        }
     }
 
     fun getMyInfo() {

--- a/app/src/main/java/com/example/resq/presentaion/usersetting/UserSettingScreen.kt
+++ b/app/src/main/java/com/example/resq/presentaion/usersetting/UserSettingScreen.kt
@@ -85,9 +85,7 @@ fun UserSettingScreen(
                 onClick = {
                     activity?.let {
                         signOut(it) {
-                            val viewmodel = GoogleSignViewModel()
-                            viewmodel.removeUserToken(context)
-                            viewmodel.signOut(googleSignInClient)
+                            GoogleSignViewModel().signOut(context, googleSignInClient)
                             it.finish()
                         }
                     }


### PR DESCRIPTION
- 로그아웃과 토큰 삭제 함수 하나로 합쳐서 간소화 
-> 로직 상 차이는 없음
- 응급 대처법 상세화면에서 온열/한랭 질환 케이스처럼 여러 결과값을 받아올 경우를 위해 리스트 형태로 수정 
-> 각 케이스 별로 즐겨찾기 조회 및 추가/삭제 할 수 있도록 수정